### PR TITLE
Fix NextPlayer calculation

### DIFF
--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -28,7 +28,7 @@ public partial class GameManager : Node2D
         Players.FirstOrDefault(p =>
             p.PlayerSeqNo == (_isClockwise
                 ? (_currentPlayerIndex + 1) % Players.Count
-                : (_currentPlayerIndex - 1) + Players.Count % Players.Count)); // 當前玩家手牌的 PlayerId
+                : (_currentPlayerIndex - 1 + Players.Count) % Players.Count)); // 當前玩家手牌的 PlayerId
 
 
     public Node2D DropZonePileNode;


### PR DESCRIPTION
## Summary
- correct the expression that calculates the next player when the turn order is counter‑clockwise

## Testing
- `dotnet build UnoCardGame.csproj -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d6553d6c832cba756e7337cd0117