### PR TITLE
Fix penalty skip logic

### DIFF
--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -568,7 +568,7 @@ public partial class GameManager : Node2D
             {
                 await _gameStateMachine.DealingCardsToPlayerAsync(NextPlayer, 4, false, false);
             }
-            NextTurn();
+            NextTurn(2);
             // SetCurrentPlayerHandActive();
 
         }
@@ -583,7 +583,7 @@ public partial class GameManager : Node2D
             {
                 await _gameStateMachine.DealingCardsToPlayerAsync(NextPlayer, 2, false, false);
             }
-            NextTurn();
+            NextTurn(2);
         }
         else if (card.CardType == CardType.Skip)
         {


### PR DESCRIPTION
## Summary
- ensure players drawing penalties skip their turn in `GameManager.CardEffect`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849173a1e0c832cb3514d275b8aabcd