### PR TITLE
Handle 2-player reverse

### DIFF
--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -594,7 +594,14 @@ public partial class GameManager : Node2D
         else if (card.CardType == CardType.Reverse)
         {
             await ReverseDirection();
-            NextTurn();
+            if (Players.Count == 2)
+            {
+                NextTurn(2);
+            }
+            else
+            {
+                NextTurn();
+            }
             // SetCurrentPlayerHandActive();
         }
         else
@@ -664,7 +671,14 @@ public partial class GameManager : Node2D
 
 
             await ReverseDirection();
-            NextTurn();
+            if (Players.Count == 2)
+            {
+                NextTurn(2);
+            }
+            else
+            {
+                NextTurn();
+            }
             if (TestMode) ShowCurrentPlayerCard();
             SetCurrentPlayerHandActive();
         }


### PR DESCRIPTION
## Summary
- when playing a Reverse card with only two players, immediately return the turn to the current player
- keep the same logic in test mode

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491850510c832c91b0b192466da971