### PR TITLE
Fix duplicate win check

### DIFF
--- a/Scripts/DragManager.cs
+++ b/Scripts/DragManager.cs
@@ -90,7 +90,6 @@ public partial class DragManager : Node2D
                     await playerHand.ReorderHand();
 
                     await _gameManager.CardEffect(card);
-                    _gameManager.IsPlayerWin();
                     return;
                 }
             }


### PR DESCRIPTION
## Summary
- remove the redundant `IsPlayerWin` call in `DragManager`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491a4b28b8832ca7a028447422240d