### PR TITLE
Implement state-based card play flow

### DIFF
--- a/Scripts/DragManager.cs
+++ b/Scripts/DragManager.cs
@@ -81,15 +81,9 @@ public partial class DragManager : Node2D
                     var dropZoneTopCard = _dropZone.GetTopCardInDropZone();
                     dropZoneTopCard.ResetBorder();
                     card.IsInteractive = false;
-                    // var playerHand = card.GetParentOrNull<Player>();
-                    // if (playerHand == null) return;
-                    var playerHand = _gameManager.CurrentPlayer;
 
-                    await _gameManager.MoveCardToTarget(card, playerHand, _dropZone,
-                        showAnimation: false);
-                    await playerHand.ReorderHand();
-
-                    await _gameManager.CardEffect(card);
+                    _gameStateMachine.CurrentPlayedCard = card;
+                    await _gameStateMachine.ChangeState(GameState.PlayerPlayCard);
                     return;
                 }
             }

--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -70,6 +70,7 @@ public partial class GameManager : Node2D
 
     private Card _currentTopCard; // 新增
     private GameStateMachine _gameStateMachine;
+    public GameStateMachine StateMachine => _gameStateMachine;
     public WildColorSelector ColorSelector;
     public VBoxContainer TestButtonGroup;
     public Button PassButton;
@@ -315,7 +316,6 @@ public partial class GameManager : Node2D
 
     public void NextTurn(int skip = 1)
     {
-        var isWin = IsPlayerWin();
         if (_isClockwise)
         {
             _currentPlayerIndex = (_currentPlayerIndex + skip) % Players.Count;
@@ -326,7 +326,6 @@ public partial class GameManager : Node2D
         }
 
         UpdateCurrentPlayerUI();
-        if (isWin) return;
 
         if (CurrentPlayer != MyPlayer)
         {
@@ -529,107 +528,10 @@ public partial class GameManager : Node2D
     }
 
 
-    public async Task CardEffect(Card card)
-    {
-
-        if (card.CardType == CardType.Wild)
-        {
-            if (CurrentPlayer == MyPlayer)
-            {
-                CardColor selectColor = await ColorSelector.ShowAndWait();
-                card.CardColor = selectColor; // 更新卡片顏色
-                card.SetWildColor(selectColor);
-            }
-            else
-            {
-                // 如果是電腦玩家，隨機選擇顏色
-                GD.Randomize();
-                var index = (int)(GD.Randi() % 4); // 0 ~ 3 對應 Red, Yellow, Green, Blue
-                var randomColor = (CardColor)index;
-                card.SetWildColor(randomColor);
-            }
-            NextTurn();
-
-        }
-        else if (card.CardType == CardType.WildDrawFour)
-        {
-
-            if (CurrentPlayer == MyPlayer)
-            {
-                CardColor selectColor = await ColorSelector.ShowAndWait();
-                card.CardColor = selectColor; // 更新卡片顏色
-                card.SetWildColor(selectColor);
-
-            }
-            else
-            {
-                // 如果是電腦玩家，隨機選擇顏色
-                GD.Randomize();
-                var index = (int)(GD.Randi() % 4); // 0 ~ 3 對應 Red, Yellow, Green, Blue
-                var randomColor = (CardColor)index;
-                card.SetWildColor(randomColor);
-            }
-
-            if (NextPlayer == MyPlayer)
-            {
-                await _gameStateMachine.DealingCardsToPlayerAsync(NextPlayer, 4);
-                await NextPlayer.ReorderHand();
-            }
-            else
-            {
-                await _gameStateMachine.DealingCardsToPlayerAsync(NextPlayer, 4, false, false);
-            }
-            NextTurn(2);
-            // SetCurrentPlayerHandActive();
-
-        }
-        else if (card.CardType == CardType.DrawTwo)
-        {
-            if (NextPlayer == MyPlayer)
-            {
-                await _gameStateMachine.DealingCardsToPlayerAsync(NextPlayer, 2);
-                await NextPlayer.ReorderHand();
-            }
-            else
-            {
-                await _gameStateMachine.DealingCardsToPlayerAsync(NextPlayer, 2, false, false);
-            }
-            NextTurn(2);
-        }
-        else if (card.CardType == CardType.Skip)
-        {
-
-            NextTurn(2);
-            // SetCurrentPlayerHandActive();
-        }
-        else if (card.CardType == CardType.Reverse)
-        {
-            await ReverseDirection();
-            if (Players.Count == 2)
-            {
-                NextTurn(2);
-            }
-            else
-            {
-                NextTurn();
-            }
-            // SetCurrentPlayerHandActive();
-        }
-        else
-        {
-            NextTurn();
-        }
-    }
 
     public bool IsPlayerWin()
     {
-        if (CurrentPlayer.GetPlayerHandCards().Count == 0)
-        {
-            GameOverUI.GetNode<Label>("PanelContainer/VBoxContainer/PlayerWinLabel").Text = $"{CurrentPlayer.Name} wins!";
-            GameOverUI.Visible = true;
-            return true;
-        }
-        return false;
+        return CurrentPlayer.GetPlayerHandCards().Count == 0;
     }
 
     public async Task TestCardEffect(Card card)

--- a/Scripts/GameStateMachine.cs
+++ b/Scripts/GameStateMachine.cs
@@ -23,6 +23,11 @@ public partial class GameStateMachine : Node
 
     public GameState CurrentState { get; private set; }
 
+    /// <summary>
+    /// The card that has been played and awaiting resolution.
+    /// </summary>
+    public Card? CurrentPlayedCard { get; set; }
+
     public override void _Ready()
     {
         _gameManager = GetParent<GameManager>();

--- a/Scripts/Player.cs
+++ b/Scripts/Player.cs
@@ -56,19 +56,10 @@ public partial class Player : Node2D
             return;
         }
         var firstCard = validCards.First();
-        await _gameManager.MoveCardToTarget(firstCard, _gameManager.PlayerZone, _gameManager.DropZonePileNode);
         firstCard.IsInteractive = false;
 
-        if (firstCard.CardType == CardType.Wild || firstCard.CardType == CardType.WildDrawFour)
-        {
-            GD.Randomize();
-            var index = (int)(GD.Randi() % 4); // 0 ~ 3 對應 Red, Yellow, Green, Blue
-            var randomColor = (CardColor)index;
-            firstCard.SetWildColor(randomColor);
-            await _gameManager.CardEffect(firstCard);
-            return;
-        }
-        await _gameManager.CardEffect(firstCard);
+        _gameManager.StateMachine.CurrentPlayedCard = firstCard;
+        await _gameManager.StateMachine.ChangeState(GameState.PlayerPlayCard);
     }
 
     public async Task ReorderHand()

--- a/Scripts/States/CheckWinOrNextTurnState.cs
+++ b/Scripts/States/CheckWinOrNextTurnState.cs
@@ -4,8 +4,35 @@ public class CheckWinOrNextTurnState : BaseGameState
 {
     public CheckWinOrNextTurnState(GameStateMachine stateMachine, GameManager gameManager) : base(stateMachine, gameManager) { }
 
-    public override Task EnterState()
+    public override async Task EnterState()
     {
-        return Task.CompletedTask;
+        if (GameManager.IsPlayerWin())
+        {
+            await StateMachine.ChangeState(GameState.GameOver);
+            return;
+        }
+
+        int skip = 1;
+        var card = StateMachine.CurrentPlayedCard;
+        if (card != null)
+        {
+            switch (card.CardType)
+            {
+                case CardType.WildDrawFour:
+                case CardType.DrawTwo:
+                case CardType.Skip:
+                    skip = 2;
+                    break;
+                case CardType.Reverse:
+                    if (GameManager.Players.Count == 2)
+                        skip = 2;
+                    break;
+            }
+        }
+
+        GameManager.NextTurn(skip);
+        StateMachine.CurrentPlayedCard = null;
+
+        await StateMachine.ChangeState(GameState.WaitForPlayerAction);
     }
 }

--- a/Scripts/States/GameOverState.cs
+++ b/Scripts/States/GameOverState.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Godot;
 
 public class GameOverState : BaseGameState
 {
@@ -6,6 +7,9 @@ public class GameOverState : BaseGameState
 
     public override Task EnterState()
     {
+        GameManager.GameOverUI.GetNode<Label>("PanelContainer/VBoxContainer/PlayerWinLabel").Text = $"{GameManager.CurrentPlayer.Name} wins!";
+        GameManager.GameOverUI.Visible = true;
+        GameManager.GetTree().Paused = true;
         return Task.CompletedTask;
     }
 }

--- a/Scripts/States/PlayerPlayCardState.cs
+++ b/Scripts/States/PlayerPlayCardState.cs
@@ -4,8 +4,19 @@ public class PlayerPlayCardState : BaseGameState
 {
     public PlayerPlayCardState(GameStateMachine stateMachine, GameManager gameManager) : base(stateMachine, gameManager) { }
 
-    public override Task EnterState()
+    public override async Task EnterState()
     {
-        return Task.CompletedTask;
+        var card = StateMachine.CurrentPlayedCard;
+        if (card != null)
+        {
+            var playerHand = GameManager.CurrentPlayer;
+            if (card.GetParent() != GameManager.DropZonePileNode)
+            {
+                await GameManager.MoveCardToTarget(card, playerHand, GameManager.DropZonePileNode, showAnimation: false);
+                await playerHand.ReorderHand();
+            }
+        }
+
+        await StateMachine.ChangeState(GameState.ResolveEffect);
     }
 }

--- a/Scripts/States/ResolveEffectState.cs
+++ b/Scripts/States/ResolveEffectState.cs
@@ -1,11 +1,75 @@
 using System.Threading.Tasks;
+using Godot;
 
 public class ResolveEffectState : BaseGameState
 {
     public ResolveEffectState(GameStateMachine stateMachine, GameManager gameManager) : base(stateMachine, gameManager) { }
 
-    public override Task EnterState()
+    public override async Task EnterState()
     {
-        return Task.CompletedTask;
+        var card = StateMachine.CurrentPlayedCard;
+        if (card != null)
+        {
+            if (card.CardType == CardType.Wild)
+            {
+                if (GameManager.CurrentPlayer == GameManager.MyPlayer)
+                {
+                    CardColor selectColor = await GameManager.ColorSelector.ShowAndWait();
+                    card.CardColor = selectColor;
+                    card.SetWildColor(selectColor);
+                }
+                else
+                {
+                    GD.Randomize();
+                    var index = (int)(GD.Randi() % 4);
+                    var randomColor = (CardColor)index;
+                    card.SetWildColor(randomColor);
+                }
+            }
+            else if (card.CardType == CardType.WildDrawFour)
+            {
+                if (GameManager.CurrentPlayer == GameManager.MyPlayer)
+                {
+                    CardColor selectColor = await GameManager.ColorSelector.ShowAndWait();
+                    card.CardColor = selectColor;
+                    card.SetWildColor(selectColor);
+                }
+                else
+                {
+                    GD.Randomize();
+                    var index = (int)(GD.Randi() % 4);
+                    var randomColor = (CardColor)index;
+                    card.SetWildColor(randomColor);
+                }
+
+                if (GameManager.NextPlayer == GameManager.MyPlayer)
+                {
+                    await StateMachine.DealingCardsToPlayerAsync(GameManager.NextPlayer, 4);
+                    await GameManager.NextPlayer.ReorderHand();
+                }
+                else
+                {
+                    await StateMachine.DealingCardsToPlayerAsync(GameManager.NextPlayer, 4, false, false);
+                }
+            }
+            else if (card.CardType == CardType.DrawTwo)
+            {
+                if (GameManager.NextPlayer == GameManager.MyPlayer)
+                {
+                    await StateMachine.DealingCardsToPlayerAsync(GameManager.NextPlayer, 2);
+                    await GameManager.NextPlayer.ReorderHand();
+                }
+                else
+                {
+                    await StateMachine.DealingCardsToPlayerAsync(GameManager.NextPlayer, 2, false, false);
+                }
+            }
+            else if (card.CardType == CardType.Reverse)
+            {
+                await GameManager.ReverseDirection();
+            }
+        }
+
+        await StateMachine.ChangeState(GameState.CheckWinOrNextTurn);
     }
 }


### PR DESCRIPTION
## Summary
- track the card currently being played in `GameStateMachine`
- trigger state transitions from `DragManager` and AI player actions
- implement `PlayerPlayCardState`, `ResolveEffectState`, `CheckWinOrNextTurnState`, and `GameOverState`
- simplify `GameManager` to remove old card effect logic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849314076a4832c89422468edc5a13d