### PR TITLE
Fix computer play origin and stacking order

### DIFF
--- a/Scripts/Card.cs
+++ b/Scripts/Card.cs
@@ -139,7 +139,6 @@ public partial class Card : Area2D
 
     public void SetAlwaysOnTop()
     {
-        if (!IsInteractive) return;
         ZAsRelative = false; // 確保 ZIndex 是全局有效的
         ZIndex = _globalZCounter++;
     }

--- a/Scripts/States/PlayerPlayCardState.cs
+++ b/Scripts/States/PlayerPlayCardState.cs
@@ -12,9 +12,14 @@ public class PlayerPlayCardState : BaseGameState
             var playerHand = GameManager.CurrentPlayer;
             if (card.GetParent() != GameManager.DropZonePileNode)
             {
-
                 bool animate = GameManager.CurrentPlayer != GameManager.MyPlayer;
-                await GameManager.MoveCardToTarget(card, playerHand, GameManager.DropZonePileNode, showAnimation: animate);
+
+                Node2D fromNode = GameManager.CurrentPlayer == GameManager.MyPlayer
+                    ? playerHand
+                    : GameManager.PlayerZone;
+
+                await GameManager.MoveCardToTarget(card, fromNode, GameManager.DropZonePileNode,
+                    showAnimation: animate);
 
                 await playerHand.ReorderHand();
             }


### PR DESCRIPTION
## Summary
- ensure AI played cards originate from `PlayerZone`
- always bring moved cards to the top of the pile

## Testing
- `dotnet --version` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684938c251fc832c93a393b8d2713f36