### PR TITLE
Fix GameOver UI input when paused

### DIFF
--- a/Scripts/GameOverUI.cs
+++ b/Scripts/GameOverUI.cs
@@ -5,7 +5,9 @@ public partial class GameOverUI : Control
 {
     public override void _Ready()
     {
-
+        // Ensure this UI continues to receive input even when the
+        // scene tree is paused after the game ends.
+        PauseMode = PauseModeEnum.Process;
     }
 
     public override void _Input(InputEvent @event)


### PR DESCRIPTION
## Summary
- ensure GameOverUI processes input even while the tree is paused

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493cbd2ef4832c9890ef145c5b5889