### PR TITLE
Fix paused game over UI processing

### DIFF
--- a/Scripts/GameOverUI.cs
+++ b/Scripts/GameOverUI.cs
@@ -7,7 +7,11 @@ public partial class GameOverUI : Control
     {
         // Ensure this UI continues to receive input even when the
         // scene tree is paused after the game ends.
-        PauseMode = PauseModeEnum.Process;
+        // `ProcessMode` replaces `PauseMode` in Godot 4 to control
+        // whether the node processes while the scene tree is paused.
+        // Using `Always` allows the UI to respond regardless of the
+        // tree's paused state.
+        ProcessMode = ProcessModeEnum.Always;
     }
 
     public override void _Input(InputEvent @event)


### PR DESCRIPTION
## Summary
- update `GameOverUI` to use the new `ProcessMode` API

## Testing
- `dotnet build UnoCardGame.csproj` *(fails: dotnet not found)*
- `godot -s Scripts/GameOverUI.cs` *(fails: godot not found)*

------
https://chatgpt.com/codex/tasks/task_e_684941abc6e0832c862c71fa6a8d2c35