### PR TITLE
Fix NetworkManager to use CustomMultiplayer

### DIFF
--- a/Scripts/NetworkManager.cs
+++ b/Scripts/NetworkManager.cs
@@ -16,7 +16,7 @@ public partial class NetworkManager : Node
 
     public override void _Ready()
     {
-        Multiplayer.MultiplayerPeer = _multiplayer;
+        CustomMultiplayer = _multiplayer;
         Multiplayer.PeerConnected += OnPeerConnected;
         Multiplayer.PeerDisconnected += OnPeerDisconnected;
     }


### PR DESCRIPTION
## Summary
- assign `_multiplayer` to `CustomMultiplayer` instead of `Multiplayer.MultiplayerPeer`
- keep peer connection events intact

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496cd142c4832c9385684a92bbc692