### PR TITLE
Fix multiplayer peer initialization

### DIFF
--- a/Scripts/NetworkManager.cs
+++ b/Scripts/NetworkManager.cs
@@ -22,17 +22,17 @@ public partial class NetworkManager : Node
 
     public void HostGame()
     {
-        var peer = new ENetMultiplayerPeer();
-        peer.CreateServer(Port, MaxPlayers);
-        Multiplayer.MultiplayerPeer = peer;
+        _multiplayer = new ENetMultiplayerPeer();
+        _multiplayer.CreateServer(Port, MaxPlayers);
+        Multiplayer.MultiplayerPeer = _multiplayer;
         GD.Print($"Hosting game on port {Port}");
     }
 
     public void JoinGame(string address)
     {
-        var peer = new ENetMultiplayerPeer();
-        peer.CreateClient(address, Port);
-        Multiplayer.MultiplayerPeer = peer;
+        _multiplayer = new ENetMultiplayerPeer();
+        _multiplayer.CreateClient(address, Port);
+        Multiplayer.MultiplayerPeer = _multiplayer;
         GD.Print($"Joining {address}:{Port}");
     }
 


### PR DESCRIPTION
## Summary
- keep ENetMultiplayerPeer instance in `_multiplayer`
- use the field for server and client creation

## Testing
- `dotnet build UnoCardGame.csproj -c Release` *(fails: Unable to find package Godot.NET.Sdk)*

------
https://chatgpt.com/codex/tasks/task_e_684a21479928832c88cbdda9d841a48b