### PR TITLE
Add leave game support

### DIFF
--- a/Scripts/GameOverUI.cs
+++ b/Scripts/GameOverUI.cs
@@ -20,6 +20,7 @@ public partial class GameOverUI : Control
         {
             // 點擊左鍵時關閉遊戲結束畫面
             GetTree().Paused = false; // 解除暫停
+            NetworkManager.Instance.LeaveGame();
             GetTree().ChangeSceneToFile("res://Scenes/uno_main_menu.tscn");
         }
     }

--- a/Scripts/NetworkManager.cs
+++ b/Scripts/NetworkManager.cs
@@ -36,6 +36,17 @@ public partial class NetworkManager : Node
         GD.Print($"Joining {address}:{Port}");
     }
 
+    public void LeaveGame()
+    {
+        if (_multiplayer != null)
+        {
+            _multiplayer.Close();
+            Multiplayer.MultiplayerPeer = null;
+            GD.Print("Left game");
+            _multiplayer = null;
+        }
+    }
+
     private void OnPeerConnected(long id)
     {
         GD.Print($"Peer connected: {id}");

--- a/Scripts/UnoMainMenu.cs
+++ b/Scripts/UnoMainMenu.cs
@@ -37,6 +37,7 @@ public partial class UnoMainMenu : Control
 
     private void OnExitPressed()
     {
+        NetworkManager.Instance.LeaveGame();
         GetTree().Quit();
     }
 }


### PR DESCRIPTION
## Summary
- provide `LeaveGame()` in `NetworkManager` to close the peer
- call `LeaveGame()` when exiting the game from the menu or game over screen

## Testing
- `dotnet build UnoCardGame.csproj -v minimal` *(fails: NU1301 - failed to retrieve packages)*

------
https://chatgpt.com/codex/tasks/task_e_684a233b9dfc832ca4b99206ff283964