### PR TITLE
Deterministic MyPlayer selection

### DIFF
--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -284,8 +284,11 @@ public partial class GameManager : Node2D
             Players.Add(newPlayer);
         }
 
-        var random = new Random();
-        MyPlayer = Players[random.Next(Players.Count)];
+        // Determine the local player based on the Multiplayer peer id so that
+        // every client chooses the same index. Godot assigns peer ids starting
+        // from 1, therefore we map `peerId - 1` to the Players list.
+        var peerId = (int)Multiplayer.GetUniqueId();
+        MyPlayer = Players[(peerId - 1) % Players.Count];
         MyPlayerNameLabel.Text = MyPlayer.Name;
 
         foreach (var player in Players)


### PR DESCRIPTION
## Summary
- map Multiplayer peer ID to player index so all peers pick the same `MyPlayer`

## Testing
- `dotnet build` *(fails: could not restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_684a2455f588832cb61472e98f9fc64e